### PR TITLE
build: debug suspend can be passed as an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ USER vertx
 WORKDIR /srv/springboard
 EXPOSE 8090
 
-CMD java -agentlib:jdwp=transport=dt_socket,address=5000,server=y,suspend=n -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar /opt/vertx-service-launcher.jar -Dvertx.services.path=/srv/springboard/mods -Dvertx.disableFileCaching=true -conf /srv/springboard/conf/vertx.conf
-
+CMD java -agentlib:jdwp=transport=dt_socket,address=5000,server=y,suspend=${DEBUG_SUSPEND:-n} -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar /opt/vertx-service-launcher.jar -Dvertx.services.path=/srv/springboard/mods -Dvertx.disableFileCaching=true -conf /srv/springboard/conf/vertx.conf


### PR DESCRIPTION
Pour les besoins de debug du démarrage de vertx, j'ai rendu paramétrable le "suspend" de vertx via une variable d'environnement à passer dans le docker-compose.xml du springboard. Si la variable n'est pas settée dans le docker-compose, la valeur par défaut de suspend est 'n'.