### PR TITLE
fix(vertx-downgrade): 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,15 +20,15 @@
 
     <groupId>com.opendigitaleducation</groupId>
     <artifactId>vertx-service-launcher</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
     <properties>
         <java.version>1.8</java.version>
-        <vertx.version>3.9.14</vertx.version>
+        <vertx.version>3.9.5</vertx.version>
         <dockerfile-maven-version>1.3.7</dockerfile-maven-version>
         <junit.version>4.12</junit.version>
         <micrometer.version>1.1.0</micrometer.version>
-        <vertx.micrometer.metrics>3.9.14</vertx.micrometer.metrics>
+        <vertx.micrometer.metrics>3.9.5</vertx.micrometer.metrics>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

# Description

The upgrade to 3.9.14 seems to come with some regressions in form handling and other features not fully identified that prevent the ENT from operating correctly so the upgrade has been postponed.