### PR TITLE
feat: #RBACK-125, add the possibility to inject environment variables into ent configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.3-eclipse-temurin-8-focal as builder
+FROM maven:3.9.3-eclipse-temurin-8-focal AS builder
 WORKDIR /opt/vertx-service-launcher
 COPY pom.xml .
 COPY ./src ./src

--- a/build-image.sh
+++ b/build-image.sh
@@ -9,7 +9,7 @@ ARCHITECTURE="linux/arm/v7,linux/arm64,linux/amd64"
 
 BRANCH_NAME=`git branch | sed -n -e "s/^\* \(.*\)/\1/p"`
 if [ "$BRANCH_NAME" = "master" ]; then
-    LATEST_TAG="opendigitaleducation/vertx-service-launcher:latest"
+    LATEST_TAG="-t opendigitaleducation/vertx-service-launcher:latest"
 else
     LATEST_TAG=""
 fi

--- a/build-image.sh
+++ b/build-image.sh
@@ -6,7 +6,12 @@ VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 JAR_FILE="vertx-service-launcher-$VERSION-fat.jar"
 TAG="opendigitaleducation/vertx-service-launcher:$VERSION"
 ARCHITECTURE="linux/arm/v7,linux/arm64,linux/amd64"
-docker buildx build --push -t "$TAG" . -f Dockerfile --build-arg JAR_FILE="$JAR_FILE" --platform $ARCHITECTURE
-TAG="opendigitaleducation/vertx-service-launcher:$VERSION-jenkins"
-docker buildx build --push -t "$TAG" . -f Dockerfile.jenkins --build-arg JAR_FILE="$JAR_FILE" --platform $ARCHITECTURE
-#docker login
+
+BRANCH_NAME=`git branch | sed -n -e "s/^\* \(.*\)/\1/p"`
+if [ "$BRANCH_NAME" = "master" ]; then
+    LATEST_TAG="opendigitaleducation/vertx-service-launcher:latest"
+else
+    LATEST_TAG=""
+fi
+
+docker buildx build --push -t "$TAG" $LATEST_TAG . -f Dockerfile --build-arg JAR_FILE="$JAR_FILE" --platform $ARCHITECTURE

--- a/src/main/java/com/opendigitaleducation/launcher/logger/AccessLogHandler.java
+++ b/src/main/java/com/opendigitaleducation/launcher/logger/AccessLogHandler.java
@@ -1,0 +1,17 @@
+package com.opendigitaleducation.launcher.logger;
+
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
+
+public class AccessLogHandler extends StreamHandler {
+
+  public AccessLogHandler() {
+    super(System.out, new JsonAccessFormatter());
+  }
+
+  @Override
+  public void publish(LogRecord record) {
+    super.publish(record);
+    flush();
+  }
+}

--- a/src/main/java/com/opendigitaleducation/launcher/logger/ENTLogHandler.java
+++ b/src/main/java/com/opendigitaleducation/launcher/logger/ENTLogHandler.java
@@ -1,0 +1,17 @@
+package com.opendigitaleducation.launcher.logger;
+
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
+
+public class ENTLogHandler extends StreamHandler {
+
+  public ENTLogHandler() {
+    super(System.out, new JsonENTFormatter());
+  }
+
+  @Override
+  public void publish(LogRecord record) {
+    super.publish(record);
+    flush();
+  }
+}

--- a/src/main/java/com/opendigitaleducation/launcher/logger/JsonAccessFormatter.java
+++ b/src/main/java/com/opendigitaleducation/launcher/logger/JsonAccessFormatter.java
@@ -1,0 +1,40 @@
+package com.opendigitaleducation.launcher.logger;
+
+import io.vertx.core.json.JsonObject;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+public class JsonAccessFormatter extends Formatter {
+
+  @Override
+  public String format(LogRecord record) {
+    JsonObject logEntry = new JsonObject()
+      .put("timestamp", Instant.ofEpochMilli(record.getMillis()).toString())
+      .put("logger", record.getLoggerName());
+    final String message = record.getMessage();
+    try {
+      JsonObject messageJson = new JsonObject(message);
+      logEntry.mergeIn(messageJson);
+    } catch (Exception e) {
+      logEntry.put("message", message);
+    }
+
+    if (record.getThrown() != null) {
+        try {
+          StringWriter sw = new StringWriter();
+          PrintWriter pw = new PrintWriter(sw);
+          record.getThrown().printStackTrace(pw);
+          pw.close();
+          logEntry.put("exception", sw.toString());
+        } catch (Exception ex) {
+          logEntry.put("exception", record.getThrown().toString());
+        }
+    }
+
+    return logEntry.encode() + System.lineSeparator();
+  }
+}

--- a/src/main/java/com/opendigitaleducation/launcher/logger/JsonENTFormatter.java
+++ b/src/main/java/com/opendigitaleducation/launcher/logger/JsonENTFormatter.java
@@ -1,0 +1,35 @@
+package com.opendigitaleducation.launcher.logger;
+
+import io.vertx.core.json.JsonObject;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+public class JsonENTFormatter extends Formatter {
+
+  @Override
+  public String format(LogRecord record) {
+    JsonObject logEntry = new JsonObject()
+      .put("timestamp", Instant.ofEpochMilli(record.getMillis()).toString())
+      .put("level", record.getLevel().toString())
+      .put("logger", record.getLoggerName())
+      .put("message", record.getMessage());
+
+    if (record.getThrown() != null) {
+        try {
+          StringWriter sw = new StringWriter();
+          PrintWriter pw = new PrintWriter(sw);
+          record.getThrown().printStackTrace(pw);
+          pw.close();
+          logEntry.put("exception", sw.toString());
+        } catch (Exception ex) {
+          logEntry.put("exception", record.getThrown().toString());
+        }
+    }
+
+    return logEntry.encode() + System.lineSeparator();
+  }
+}


### PR DESCRIPTION
Cette PR ajoute la possibilité d'injecter des variables d'environnement dans la configuration de l'ENT en respectant le formalisme suivant :
- `${ENV_VAR}`, remplace par la valeur de la variable d'environnement `ENV_VAR` si elle existe ou par une chaîne vide sinon
- `${!ENV_VAR}`, remplace par la valeur de la variable d'environnement `ENV_VAR` si elle existe ou lève une exception si elle n'existe pas
- `${ENV_VAR:default value}:`, remplace par la valeur de la variable d'environnement `ENV_VAR` si elle existe ou par `default value` si la variable d'env n'existe pas